### PR TITLE
Change the dependabot strategy to lockfile-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@
 version: 2
 updates:
   - package-ecosystem: pip
+    versioning-strategy: lockfile-only
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
We have the constraints in our `requirements.in` to allow us to build on Python 3.6, and things break if dependabot tries to change them. Instead, instruct it to just update the lockfile.