### PR TITLE
Add support for toctrees without captions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: Lints
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/themes/ferrocene/static/ferrocene.css
+++ b/themes/ferrocene/static/ferrocene.css
@@ -385,9 +385,17 @@ nav label.toggle:hover {
     color: var(--sidebar-active-fg);
 }
 
+nav div.toctree {
+    padding: 1.25rem 0 1rem 0;
+}
+
 nav p.caption {
     font-weight: 700;
     margin: 1.25rem 1rem 0.5rem 1rem;
+}
+
+nav p.caption:first-child {
+    margin-top: 0;
 }
 
 nav ul {
@@ -411,10 +419,6 @@ nav a:hover,
 nav a.current {
     color: var(--sidebar-active-fg);
     text-decoration: none;
-}
-
-div.toctree {
-    padding-bottom: 1rem;
 }
 
 /********************


### PR DESCRIPTION
This PR adds support for toctrees without captions in the Sphinx theme, by ensuring the margin at the top of toctrees is present even when no caption is there.

Example in a local branch of the spec repository (that removes the caption):

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2299951/203941701-839f02e2-27f7-4d22-9fd6-85d2f9b78963.png) | ![image](https://user-images.githubusercontent.com/2299951/203941738-102196d2-c61f-41e7-a5cd-a9f854009b3d.png) |

