### PR TITLE
Remove the `ferrocene_appendices` extension

### DIFF
--- a/exts/ferrocene_appendices.py
+++ b/exts/ferrocene_appendices.py
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
-
-# Compatibility with the old extension name.
-from ferrocene_toctrees import setup
-
-__all__ = ["setup"]


### PR DESCRIPTION
The extension has been replaced by `ferrocene_toctrees`, and the current version just re-exported `ferrocene_toctrees`. All of our documentation has been migrated to the new extension, so this is not needed anymore.